### PR TITLE
Add first draft of archive_db.py, README, and setup files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+archive-*
 venv
 env.json
 *.csv

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+venv
+env.json
+*.csv

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ When the prerequisites are satisfied, perform the actions below in order.
 
     If you are using Windows, you will need to follow a different process for installing `mysqlclient`.
 
-    * Go to [Unofficial Windows Binaries for Python Extension Packages](https://www.lfd.uci.edu/~gohlke/pythonlibs/#mysqlclient) and search for "mysqlclient-1.4.6" and find the `.whl` download corresponding to your type of processor (32 or 64).
+    * Go to [Unofficial Windows Binaries for Python Extension Packages](https://www.lfd.uci.edu/~gohlke/pythonlibs/#mysqlclient) and search for "mysqlclient-1.4.6" and find the `.whl` download corresponding to your machine's processor (32- or 64-bit).
 
     * Within the virtual environment, issue the following command, where `[path]` is an absolute path to the wheel:
         ```
@@ -57,6 +57,8 @@ Copy and rename the file `env.json` using a text editor, file utility, or termin
     1. Replace the provided `LOG_LEVEL` value with the minimum level for log messages you want to appear in output. `INFO` or `DEBUG` is recommended for most use cases; see Python's [logging](https://docs.python.org/3/library/logging.html) module.
 
     1. Under `MYSQL_DATABASE`, replace the empty strings and `0` with the parameters for the database you wish to connect to.
+
+    1. If you would like files written elsewhere, replace the provided `OUT_PATH` with a relative or absolute path to a directory of your choice. Directories on the specified path that do not exist will be created by the application. If no value is provided for `OUT_PATH`, the application will default to the `data` directory included in the repository.
 
 
 ### Usage

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## archive_db.py
 
-This small Python application allows the user to connect to a MySQL database and write the data from each table to a CSV file. The application writes all of the resulting files to an `archive` directory named using the database's name and host, as well as the date and time it was downloaded.
+This small Python application allows the user to connect to a MySQL database and write the data from each table to a CSV file. The application writes all of the resulting files to an `archive` directory named using the database's name and host, as well as the date and time the application was run.
 
 ### Installation
 
@@ -13,8 +13,8 @@ When the prerequisites are satisfied, perform the actions below in order.
 
 1. Clone the repository and navigate into it.
     ```
-    https://github.com/tl-its-umich-edu/tl-utils.git   # HTTPS
-    git@github.com:tl-its-umich-edu/tl-utils.git       # SSH
+    https://github.com/tl-its-umich-edu/archive-db.git   # HTTPS
+    git@github.com:tl-its-umich-edu/archive-db.git       # SSH
     
     cd archive-db
     ```
@@ -39,15 +39,15 @@ When the prerequisites are satisfied, perform the actions below in order.
     * Go to [Unofficial Windows Binaries for Python Extension Packages](https://www.lfd.uci.edu/~gohlke/pythonlibs/#mysqlclient) and search for "mysqlclient-1.4.6" and find the `.whl` download corresponding to your type of processor (32 or 64).
 
     * Within the virtual environment, issue the following command, where `[path]` is an absolute path to the wheel:
-    ```
-    pip install [path]
-    ```
+        ```
+        pip install [path]
+        ```
 
     * Then, install the other dependencies using `pip install -r requirements.txt`.
 
 ### Configuration
 
-Prior to trying to run the application, you will need to create a configuration file called `env.json`. 
+Prior to running the application, you will need to create a configuration file called `env.json`. 
 
 1. In the `config` directory of the repository, you will find a template file called `env_blank.json`. 
 Copy and rename the file `env.json` using a text editor, file utility, or terminal.
@@ -61,7 +61,7 @@ Copy and rename the file `env.json` using a text editor, file utility, or termin
 
 ### Usage
 
-To the run the application, simply execute `archive-db.py` within the activated virtual environment.
+To the run the application, simply execute `archive_db.py` within the activated virtual environment.
 
 ```
 python archive_db.py

--- a/README.md
+++ b/README.md
@@ -1,1 +1,70 @@
+## archive_db.py
 
+This small Python application allows the user to connect to a MySQL database and write the data from each table to a CSV file. The application writes all of the resulting files to an `archive` directory named using the database's name and host, as well as the date and time it was downloaded.
+
+### Installation
+
+To successfully set up the application, you may need to install some or all of the following:
+* Python 3 (the application was written and tested using version 3.7.5)
+* [Git](https://git-scm.com/)
+* [`virtualenv`](https://virtualenv.pypa.io/en/latest/)
+
+When the prerequisites are satisfied, perform the actions below in order. 
+
+1. Clone the repository and navigate into it.
+    ```
+    https://github.com/tl-its-umich-edu/tl-utils.git   # HTTPS
+    git@github.com:tl-its-umich-edu/tl-utils.git       # SSH
+    
+    cd archive-db
+    ```
+
+1. Create and activate a virtual environment using `virtualenv`.
+   ```
+   virtualenv venv
+
+   source venv/bin/activate   # for Mac OS
+   venv\Scripts\activate      # for Windows
+   ```
+
+1. Install the dependencies.
+
+    If you are using Mac OS, install the dependencies like so:
+    ```
+    pip install -r requirements.txt
+    ```
+
+    If you are using Windows, you will need to follow a different process for installing `mysqlclient`.
+
+    * Go to [Unofficial Windows Binaries for Python Extension Packages](https://www.lfd.uci.edu/~gohlke/pythonlibs/#mysqlclient) and search for "mysqlclient-1.4.6" and find the `.whl` download corresponding to your type of processor (32 or 64).
+
+    * Within the virtual environment, issue the following command, where `[path]` is an absolute path to the wheel:
+    ```
+    pip install [path]
+    ```
+
+    * Then, install the other dependencies using `pip install -r requirements.txt`.
+
+### Configuration
+
+Prior to trying to run the application, you will need to create a configuration file called `env.json`. 
+
+1. In the `config` directory of the repository, you will find a template file called `env_blank.json`. 
+Copy and rename the file `env.json` using a text editor, file utility, or terminal.
+
+1. Next, add the desired settings for the application. 
+    
+    1. Replace the provided `LOG_LEVEL` value with the minimum level for log messages you want to appear in output. `INFO` or `DEBUG` is recommended for most use cases; see Python's [logging](https://docs.python.org/3/library/logging.html) module.
+
+    1. Under `MYSQL_DATABASE`, replace the empty strings and `0` with the parameters for the database you wish to connect to.
+
+
+### Usage
+
+To the run the application, simply execute `archive-db.py` within the activated virtual environment.
+
+```
+python archive_db.py
+```
+
+The CSV files, each named according to the table name, will be in an `archive-` subdirectory under `data`.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## archive_db.py
 
-This small Python application allows the user to connect to a MySQL database and write the data from each table to a CSV file. The application writes all of the resulting files to an `archive` directory named using the database's name and host, as well as the date and time the application was run.
+This small Python application allows the user to connect to a MySQL database and write the data from each table to a CSV file. The application writes all of the resulting files to an `archive` directory named using the database's name, as well as the date and time the application was run.
 
 ### Installation
 
@@ -67,4 +67,4 @@ To the run the application, simply execute `archive_db.py` within the activated 
 python archive_db.py
 ```
 
-The CSV files, each named according to the table name, will be in an `archive-` subdirectory under `data`.
+The CSV files, each named according to the table name, will be in an `archive-` subdirectory under `data`. Archive directories are named according to the following scheme, with each element separated by a hyphen: "archive", the name of the database, and the local date and time (to second precision).

--- a/archive_db.py
+++ b/archive_db.py
@@ -1,0 +1,50 @@
+# standard libraries
+import logging, json
+
+# third-party libraries
+import pandas as pd
+from sqlalchemy import create_engine
+
+logger = logging.getLogger(__name__)
+logging.basicConfig()
+
+# Load config file
+try:
+    with open('config/env.json') as f:
+        ENV = json.load(f)
+except FileNotFoundError as fnfe:
+    logger.error('No configuration file was found; add env.json to the config directory.')
+
+# Initialize settings and global variables
+logger.setLevel(ENV.get('LOG_LEVEL', 'DEBUG'))
+
+OUT_DIR = ENV.get('OUT_DIR', "data")
+
+db_params = ENV['MYSQL_DATABASE']
+ENGINE = create_engine(
+    f"mysql://{db_params['USER']}" + 
+    f":{db_params['PASSWORD']}" + 
+    f"@{db_params['HOST']}:" + 
+    f"{db_params['PORT']}" + 
+    f"/{db_params['DATABASE']}?charset=utf8"
+)
+logger.info(f"Created engine for communicating with {db_params['DATABASE']} database")
+
+
+# Functions
+
+def write_tables_as_csvs():
+    table_names_series = pd.read_sql('SHOW TABLES', ENGINE).iloc[:, 0]
+    logger.debug(table_names_series)
+    for table_name in table_names_series.to_list():
+        table_df = pd.read_sql(table_name, ENGINE)
+        logger.debug(table_df.head())
+        logger.debug(table_df.columns)
+        csv_file_path = f'{OUT_DIR}/{table_name}.csv'
+        table_df.to_csv(csv_file_path, index=False)
+        logger.info(f'Wrote {table_name} table to {csv_file_path}')
+
+# Main Program
+
+if __name__ == '__main__':
+    write_tables_as_csvs()

--- a/archive_db.py
+++ b/archive_db.py
@@ -9,6 +9,9 @@ from sqlalchemy import create_engine
 logger = logging.getLogger(__name__)
 logging.basicConfig()
 
+
+# Settings and global variables
+
 # Load config file
 try:
     with open('config/env.json') as f:
@@ -16,20 +19,19 @@ try:
 except FileNotFoundError as fnfe:
     logger.error('No configuration file was found; add env.json to the config directory.')
 
-# Initialize settings and global variables
 logger.setLevel(ENV.get('LOG_LEVEL', 'DEBUG'))
 
 OUT_DIR = ENV.get('OUT_DIR', "data")
 
-db_params = ENV['MYSQL_DATABASE']
+DB_PARAMS = ENV['MYSQL_DATABASE']
 ENGINE = create_engine(
-    f"mysql://{db_params['USER']}" + 
-    f":{db_params['PASSWORD']}" + 
-    f"@{db_params['HOST']}:" + 
-    f"{db_params['PORT']}" + 
-    f"/{db_params['DATABASE']}?charset=utf8"
+    f"mysql://{DB_PARAMS['USER']}" + 
+    f":{DB_PARAMS['PASSWORD']}" + 
+    f"@{DB_PARAMS['HOST']}" + 
+    f":{DB_PARAMS['PORT']}" + 
+    f"/{DB_PARAMS['DATABASE']}?charset=utf8"
 )
-logger.info(f"Created engine for communicating with {db_params['DATABASE']} database")
+logger.info(f"Created engine for communicating with {DB_PARAMS['DATABASE']} database")
 
 
 # Function(s)
@@ -49,7 +51,9 @@ def write_tables_as_csvs(out_path):
 
 if __name__ == '__main__':
     current_str_time = datetime.now().isoformat()
-    archive_dir_name = f"archive-{ENV['MYSQL_DATABASE']['DATABASE']}-{current_str_time}"
+
+    archive_dir_name = f"archive-{DB_PARAMS['DATABASE']}@{DB_PARAMS['HOST']}-{current_str_time}"
     archive_path = f'{OUT_DIR}/{archive_dir_name}'
     os.mkdir(archive_path)
+
     write_tables_as_csvs(archive_path)

--- a/archive_db.py
+++ b/archive_db.py
@@ -21,7 +21,7 @@ except FileNotFoundError:
 logger.setLevel(ENV.get('LOGGING_LEVEL', 'DEBUG'))
 logger.info("** archive-db.py **")
 
-OUT_DIR = ENV.get('OUT_DIR', 'data')
+OUT_PATH = ENV.get('OUT_PATH', 'data')
 
 DB_PARAMS = ENV['MYSQL_DATABASE']
 ENGINE = create_engine(
@@ -36,13 +36,13 @@ logger.info(f"Created engine for communicating with {DB_PARAMS['DATABASE']} data
 
 # Function(s)
 
-def write_tables_as_csvs(out_path: str) -> None: 
+def write_tables_as_csvs(root_path: str) -> None: 
     table_names_series = pd.read_sql('SHOW TABLES;', ENGINE).iloc[:, 0]
     logger.debug(table_names_series)
     for table_name in table_names_series.to_list():
         table_df = pd.read_sql(table_name, ENGINE)
         logger.debug(table_df.head())
-        csv_file_path = f'{out_path}/{table_name}.csv'
+        csv_file_path = f'{root_path}/{table_name}.csv'
         table_df.to_csv(csv_file_path, index=False)
         logger.info(f'Wrote {table_name} table to {csv_file_path}')
 
@@ -52,14 +52,14 @@ def write_tables_as_csvs(out_path: str) -> None:
 if __name__ == '__main__':
     current_str_time = datetime.now().isoformat(timespec='seconds')
 
-    if not os.path.isdir(OUT_DIR):
-        os.makedirs(OUT_DIR)
-        logger.info(f'Created OUT_DIR {OUT_DIR} (and intermediate directories) because it did not exist')
+    if not os.path.isdir(OUT_PATH):
+        os.makedirs(OUT_PATH)
+        logger.info(f'Created directory (or directories) for OUT_PATH {OUT_PATH}')
     else:
-        logger.info(f'OUT_DIR {OUT_DIR} already exists')
+        logger.info(f'OUT_PATH {OUT_PATH} already exists')
 
     archive_dir_name = f"archive-{DB_PARAMS['DATABASE']}-{current_str_time}"
-    archive_path = f'{OUT_DIR}/{archive_dir_name}'
+    archive_path = f'{OUT_PATH}/{archive_dir_name}'
     os.mkdir(archive_path)
 
     write_tables_as_csvs(archive_path)

--- a/archive_db.py
+++ b/archive_db.py
@@ -6,13 +6,12 @@ from datetime import datetime
 import pandas as pd
 from sqlalchemy import create_engine
 
-logger = logging.getLogger(__name__)
-logging.basicConfig()
-
 
 # Settings and global variables
 
-# Load config file
+logger = logging.getLogger(__name__)
+logging.basicConfig()
+
 try:
     with open('config/env.json') as f:
         ENV = json.load(f)
@@ -21,7 +20,7 @@ except FileNotFoundError as fnfe:
 
 logger.setLevel(ENV.get('LOG_LEVEL', 'DEBUG'))
 
-OUT_DIR = ENV.get('OUT_DIR', "data")
+OUT_DIR = ENV.get('OUT_DIR', 'data')
 
 DB_PARAMS = ENV['MYSQL_DATABASE']
 ENGINE = create_engine(
@@ -37,7 +36,7 @@ logger.info(f"Created engine for communicating with {DB_PARAMS['DATABASE']} data
 # Function(s)
 
 def write_tables_as_csvs(out_path):
-    table_names_series = pd.read_sql('SHOW TABLES', ENGINE).iloc[:, 0]
+    table_names_series = pd.read_sql('SHOW TABLES;', ENGINE).iloc[:, 0]
     logger.debug(table_names_series)
     for table_name in table_names_series.to_list():
         table_df = pd.read_sql(table_name, ENGINE)

--- a/archive_db.py
+++ b/archive_db.py
@@ -49,9 +49,9 @@ def write_tables_as_csvs(out_path):
 # Main Program
 
 if __name__ == '__main__':
-    current_str_time = datetime.now().isoformat()
+    current_str_time = datetime.now().isoformat(timespec='seconds')
 
-    archive_dir_name = f"archive-{DB_PARAMS['DATABASE']}@{DB_PARAMS['HOST']}-{current_str_time}"
+    archive_dir_name = f"archive-{DB_PARAMS['DATABASE']}-{current_str_time}"
     archive_path = f'{OUT_DIR}/{archive_dir_name}'
     os.mkdir(archive_path)
 

--- a/archive_db.py
+++ b/archive_db.py
@@ -1,5 +1,6 @@
 # standard libraries
-import logging, json
+import json, logging, os
+from datetime import datetime
 
 # third-party libraries
 import pandas as pd
@@ -31,20 +32,24 @@ ENGINE = create_engine(
 logger.info(f"Created engine for communicating with {db_params['DATABASE']} database")
 
 
-# Functions
+# Function(s)
 
-def write_tables_as_csvs():
+def write_tables_as_csvs(out_path):
     table_names_series = pd.read_sql('SHOW TABLES', ENGINE).iloc[:, 0]
     logger.debug(table_names_series)
     for table_name in table_names_series.to_list():
         table_df = pd.read_sql(table_name, ENGINE)
         logger.debug(table_df.head())
-        logger.debug(table_df.columns)
-        csv_file_path = f'{OUT_DIR}/{table_name}.csv'
+        csv_file_path = f'{out_path}/{table_name}.csv'
         table_df.to_csv(csv_file_path, index=False)
         logger.info(f'Wrote {table_name} table to {csv_file_path}')
+
 
 # Main Program
 
 if __name__ == '__main__':
-    write_tables_as_csvs()
+    current_str_time = datetime.now().isoformat()
+    archive_dir_name = f"archive-{ENV['MYSQL_DATABASE']['DATABASE']}-{current_str_time}"
+    archive_path = f'{OUT_DIR}/{archive_dir_name}'
+    os.mkdir(archive_path)
+    write_tables_as_csvs(archive_path)

--- a/archive_db.py
+++ b/archive_db.py
@@ -15,10 +15,11 @@ logging.basicConfig()
 try:
     with open('config/env.json') as f:
         ENV = json.load(f)
-except FileNotFoundError as fnfe:
+except FileNotFoundError:
     logger.error('No configuration file was found; add env.json to the config directory.')
 
-logger.setLevel(ENV.get('LOG_LEVEL', 'DEBUG'))
+logger.setLevel(ENV.get('LOGGING_LEVEL', 'DEBUG'))
+logger.info("** archive-db.py **")
 
 OUT_DIR = ENV.get('OUT_DIR', 'data')
 
@@ -35,7 +36,7 @@ logger.info(f"Created engine for communicating with {DB_PARAMS['DATABASE']} data
 
 # Function(s)
 
-def write_tables_as_csvs(out_path):
+def write_tables_as_csvs(out_path: str) -> None: 
     table_names_series = pd.read_sql('SHOW TABLES;', ENGINE).iloc[:, 0]
     logger.debug(table_names_series)
     for table_name in table_names_series.to_list():
@@ -50,6 +51,12 @@ def write_tables_as_csvs(out_path):
 
 if __name__ == '__main__':
     current_str_time = datetime.now().isoformat(timespec='seconds')
+
+    if not os.path.isdir(OUT_DIR):
+        os.makedirs(OUT_DIR)
+        logger.info(f'Created OUT_DIR {OUT_DIR} (and intermediate directories) because it did not exist')
+    else:
+        logger.info(f'OUT_DIR {OUT_DIR} already exists')
 
     archive_dir_name = f"archive-{DB_PARAMS['DATABASE']}-{current_str_time}"
     archive_path = f'{OUT_DIR}/{archive_dir_name}'

--- a/config/env_blank.json
+++ b/config/env_blank.json
@@ -7,5 +7,5 @@
         "HOST": "",
         "PORT": 0
     },
-    "OUT_DIR": "data"
+    "OUT_PATH": "data"
 }

--- a/config/env_blank.json
+++ b/config/env_blank.json
@@ -6,5 +6,6 @@
         "PASSWORD": "",
         "HOST": "",
         "PORT": 0
-    }
+    },
+    "OUT_DIR": "data"
 }

--- a/config/env_blank.json
+++ b/config/env_blank.json
@@ -1,0 +1,10 @@
+{
+    "LOGGING_LEVEL": "INFO",
+    "MYSQL_DATABASE": {
+        "DATABASE": "",
+        "USER": "",
+        "PASSWORD": "",
+        "HOST": "",
+        "PORT": 0
+    }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+mysqlclient==1.4.6
+numpy==1.18.1
+pandas==1.0.0
+python-dateutil==2.8.1
+pytz==2019.3
+six==1.14.0
+SQLAlchemy==1.3.13


### PR DESCRIPTION
This PR adds a first draft of the archive_db.py utility and supporting files. The utility is designed to take any MYSQL database and write the contents of each table to a CSV file. Subdirectories are created under `data` that include database info and a timestamp to differentiate between application runs. See `README.md` for more details.