### PR TITLE
Allow for use of CA certificates when connecting to databases (#2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,8 @@ Copy and rename the file `env.json` using a text editor, file utility, or termin
 
 1. Next, add the desired settings for the application. 
     
-    1. Replace the provided `LOG_LEVEL` value with the minimum level for log messages you want to appear in output. `INFO` or `DEBUG` is recommended for most use cases; see Python's [logging](https://docs.python.org/3/library/logging.html) module.
-
+    1. Replace the provided `LOGGING_LEVEL` value with the minimum level for log messages you want to appear in output. `INFO` or `DEBUG` is recommended for most use cases; see Python's [logging](https://docs.python.org/3/library/logging.html) module.
     1. Under `MYSQL_DATABASE`, replace the empty strings and `0` with the parameters for the database you wish to connect to.
-
     1. If you would like files written elsewhere, replace the provided `OUT_PATH` with a relative or absolute path to a directory of your choice. Directories on the specified path that do not exist will be created by the application. If no value is provided for `OUT_PATH`, the application will default to the `data` directory included in the repository.
 
 

--- a/README.md
+++ b/README.md
@@ -53,11 +53,10 @@ Prior to running the application, you will need to create a configuration file c
 Copy and rename the file `env.json` using a text editor, file utility, or terminal.
 
 1. Next, add the desired settings for the application. 
-    
-     1. Under `MYSQL_DATABASE`, replace the empty strings and `0` with the parameters for the database you wish to connect to.
-     2. If you need a CA certificate to connect to the database specified in the `MYSQL_DATABASE` object, replace the `null` value for `SSL_CA_PATH` with the absolute path to your certificate.
-     3. Replace the provided `LOGGING_LEVEL` value with the minimum level for log messages you want to appear in output. `INFO` or `DEBUG` is recommended for most use cases; see Python's [logging](https://docs.python.org/3/library/logging.html) module.
-     4. If you would like output files written somewhere specific, replace the provided `OUT_PATH` with a relative or absolute path to a directory of your choice. Directories on the specified path that do not exist will be created by the application. If no value is provided for `OUT_PATH`, the application will default to the `data` directory included in the repository.
+    1. Under `MYSQL_DATABASE`, replace the empty strings and `0` with the parameters for the database you wish to connect to.
+    2. If you need a CA certificate to connect to the database specified in the `MYSQL_DATABASE` object, replace the `null` value for `SSL_CA_PATH` with the absolute path to your certificate.
+    3. Replace the provided `LOGGING_LEVEL` value with the minimum level for log messages you want to appear in output. `INFO` or `DEBUG` is recommended for most use cases; see Python's [logging](https://docs.python.org/3/library/logging.html) module.
+    4. If you would like output files written somewhere specific, replace the provided `OUT_PATH` with a relative or absolute path to a directory of your choice. Directories on the specified path that do not exist will be created by the application. If no value is provided for `OUT_PATH`, the application will default to the `data` directory included in the repository.
 
 ### Usage
 

--- a/README.md
+++ b/README.md
@@ -54,12 +54,10 @@ Copy and rename the file `env.json` using a text editor, file utility, or termin
 
 1. Next, add the desired settings for the application. 
     
-    1. Under `MYSQL_DATABASE`, replace the empty strings and `0` with the parameters for the database you wish to connect to.
-    2. If you need a CA certificate to connect to the database specified in the `MYSQL_DATABASE` object, replace the `null` value for `SSL_CA_PATH` with the absolute path to your certificate.
-    3. Replace the provided `LOGGING_LEVEL` value with the minimum level for log messages you want to appear in output. `INFO` or `DEBUG` is recommended for most use cases; see Python's [logging](https://docs.python.org/3/library/logging.html) module.
-    4. If you would like output files written somewhere specific, replace the provided `OUT_PATH` with a relative or absolute path to a directory of your choice. Directories on the specified path that do not exist will be created by the application. If no value is provided for `OUT_PATH`, the application will default to the `data` directory included in the repository.
-
-
+     1. Under `MYSQL_DATABASE`, replace the empty strings and `0` with the parameters for the database you wish to connect to.
+     2. If you need a CA certificate to connect to the database specified in the `MYSQL_DATABASE` object, replace the `null` value for `SSL_CA_PATH` with the absolute path to your certificate.
+     3. Replace the provided `LOGGING_LEVEL` value with the minimum level for log messages you want to appear in output. `INFO` or `DEBUG` is recommended for most use cases; see Python's [logging](https://docs.python.org/3/library/logging.html) module.
+     4. If you would like output files written somewhere specific, replace the provided `OUT_PATH` with a relative or absolute path to a directory of your choice. Directories on the specified path that do not exist will be created by the application. If no value is provided for `OUT_PATH`, the application will default to the `data` directory included in the repository.
 
 ### Usage
 

--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ Copy and rename the file `env.json` using a text editor, file utility, or termin
 1. Next, add the desired settings for the application. 
     
     1. Under `MYSQL_DATABASE`, replace the empty strings and `0` with the parameters for the database you wish to connect to.
-    1. If you need a CA certificate to connect to the database specified in the `MYSQL_DATABASE` object, replace the `null` value for `SSL_CA_PATH` with the absolute path to your certificate.
-    1. Replace the provided `LOGGING_LEVEL` value with the minimum level for log messages you want to appear in output. `INFO` or `DEBUG` is recommended for most use cases; see Python's [logging](https://docs.python.org/3/library/logging.html) module.
-    1. If you would like output files written somewhere specific, replace the provided `OUT_PATH` with a relative or absolute path to a directory of your choice. Directories on the specified path that do not exist will be created by the application. If no value is provided for `OUT_PATH`, the application will default to the `data` directory included in the repository.
+    2. If you need a CA certificate to connect to the database specified in the `MYSQL_DATABASE` object, replace the `null` value for `SSL_CA_PATH` with the absolute path to your certificate.
+    3. Replace the provided `LOGGING_LEVEL` value with the minimum level for log messages you want to appear in output. `INFO` or `DEBUG` is recommended for most use cases; see Python's [logging](https://docs.python.org/3/library/logging.html) module.
+    4. If you would like output files written somewhere specific, replace the provided `OUT_PATH` with a relative or absolute path to a directory of your choice. Directories on the specified path that do not exist will be created by the application. If no value is provided for `OUT_PATH`, the application will default to the `data` directory included in the repository.
 
 
 

--- a/README.md
+++ b/README.md
@@ -54,9 +54,11 @@ Copy and rename the file `env.json` using a text editor, file utility, or termin
 
 1. Next, add the desired settings for the application. 
     
-    1. Replace the provided `LOGGING_LEVEL` value with the minimum level for log messages you want to appear in output. `INFO` or `DEBUG` is recommended for most use cases; see Python's [logging](https://docs.python.org/3/library/logging.html) module.
     1. Under `MYSQL_DATABASE`, replace the empty strings and `0` with the parameters for the database you wish to connect to.
-    1. If you would like files written elsewhere, replace the provided `OUT_PATH` with a relative or absolute path to a directory of your choice. Directories on the specified path that do not exist will be created by the application. If no value is provided for `OUT_PATH`, the application will default to the `data` directory included in the repository.
+    1. If you need a CA certificate to connect to the database specified in the `MYSQL_DATABASE` object, replace the `null` value for `SSL_CA_PATH` with the absolute path to your certificate.
+    1. Replace the provided `LOGGING_LEVEL` value with the minimum level for log messages you want to appear in output. `INFO` or `DEBUG` is recommended for most use cases; see Python's [logging](https://docs.python.org/3/library/logging.html) module.
+    1. If you would like output files written somewhere specific, replace the provided `OUT_PATH` with a relative or absolute path to a directory of your choice. Directories on the specified path that do not exist will be created by the application. If no value is provided for `OUT_PATH`, the application will default to the `data` directory included in the repository.
+
 
 
 ### Usage

--- a/archive_db.py
+++ b/archive_db.py
@@ -34,7 +34,10 @@ conn_str = (
     f"/{DB_PARAMS['DATABASE']}?charset=utf8"
 )
 
-ENGINE = create_engine(conn_str, connect_args={'ssl': {'ca': SSL_CA_PATH}}) if SSL_CA_PATH else create_engine(conn_str)
+if SSL_CA_PATH:
+    ENGINE = create_engine(conn_str, connect_args={'ssl': {'ca': SSL_CA_PATH}})
+else:
+    ENGINE = create_engine(conn_str)
 logger.info(f"Created engine for communicating with {DB_PARAMS['DATABASE']} database")
 
 

--- a/archive_db.py
+++ b/archive_db.py
@@ -26,11 +26,11 @@ DB_PARAMS = ENV['MYSQL_DATABASE']
 SSL_CA_PATH = ENV.get('SSL_CA_PATH', None)
 
 conn_str = (
-    'mysql' + 
-    f"://{DB_PARAMS['USER']}" + 
-    f":{DB_PARAMS['PASSWORD']}" + 
-    f"@{DB_PARAMS['HOST']}" + 
-    f":{DB_PARAMS['PORT']}" + 
+    'mysql' +
+    f"://{DB_PARAMS['USER']}" +
+    f":{DB_PARAMS['PASSWORD']}" +
+    f"@{DB_PARAMS['HOST']}" +
+    f":{DB_PARAMS['PORT']}" +
     f"/{DB_PARAMS['DATABASE']}?charset=utf8"
 )
 

--- a/archive_db.py
+++ b/archive_db.py
@@ -22,15 +22,19 @@ logger.setLevel(ENV.get('LOGGING_LEVEL', 'DEBUG'))
 logger.info("** archive-db.py **")
 
 OUT_PATH = ENV.get('OUT_PATH', 'data')
-
+SSL_CA_PATH = ENV.get('SSL_CA_PATH', None)
 DB_PARAMS = ENV['MYSQL_DATABASE']
-ENGINE = create_engine(
-    f"mysql://{DB_PARAMS['USER']}" + 
+
+conn_str = (
+    'mysql' + 
+    f"://{DB_PARAMS['USER']}" + 
     f":{DB_PARAMS['PASSWORD']}" + 
     f"@{DB_PARAMS['HOST']}" + 
     f":{DB_PARAMS['PORT']}" + 
     f"/{DB_PARAMS['DATABASE']}?charset=utf8"
 )
+
+ENGINE = create_engine(conn_str, connect_args={'ssl': {'ca': SSL_CA_PATH}}) if SSL_CA_PATH else create_engine(conn_str)
 logger.info(f"Created engine for communicating with {DB_PARAMS['DATABASE']} database")
 
 

--- a/archive_db.py
+++ b/archive_db.py
@@ -43,7 +43,8 @@ logger.info(f"Created engine for communicating with {DB_PARAMS['DATABASE']} data
 
 # Function(s)
 
-def write_tables_as_csvs(root_path: str) -> None: 
+def write_tables_as_csvs(root_path: str) -> None:
+    logger.debug('Starting to execute queries against database...')
     table_names_series = pd.read_sql('SHOW TABLES;', ENGINE).iloc[:, 0]
     logger.debug(table_names_series)
     for table_name in table_names_series.to_list():

--- a/archive_db.py
+++ b/archive_db.py
@@ -22,8 +22,8 @@ logger.setLevel(ENV.get('LOGGING_LEVEL', 'DEBUG'))
 logger.info("** archive-db.py **")
 
 OUT_PATH = ENV.get('OUT_PATH', 'data')
-SSL_CA_PATH = ENV.get('SSL_CA_PATH', None)
 DB_PARAMS = ENV['MYSQL_DATABASE']
+SSL_CA_PATH = ENV.get('SSL_CA_PATH', None)
 
 conn_str = (
     'mysql' + 

--- a/config/env_blank.json
+++ b/config/env_blank.json
@@ -7,5 +7,6 @@
         "HOST": "",
         "PORT": 0
     },
-    "OUT_PATH": "data"
+    "OUT_PATH": "data",
+    "SSL_CA_PATH": null
 }

--- a/config/env_blank.json
+++ b/config/env_blank.json
@@ -1,5 +1,4 @@
 {
-    "LOGGING_LEVEL": "INFO",
     "MYSQL_DATABASE": {
         "DATABASE": "",
         "USER": "",
@@ -7,6 +6,7 @@
         "HOST": "",
         "PORT": 0
     },
-    "OUT_PATH": "data",
-    "SSL_CA_PATH": null
+    "SSL_CA_PATH": null,
+    "LOGGING_LEVEL": "INFO",
+    "OUT_PATH": "data"
 }


### PR DESCRIPTION
This PR makes minor changes to `archive_db.py` (and updates the template `env.json` and `README` with explanation) to allow users to specify a SSL CA certificate if they need one to connect to a MySQL database. The PR aims to resolve issue #2.